### PR TITLE
Added demo link & office hours video

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -271,6 +271,7 @@ export default function HomePage() {
                 <p className="mt-5 max-w-prose mx-auto text-xl text-gray-500">
                   Algomart is a fully-baked solution that allows you to have a completely functional NFT marketplace as your jumping off point. Get your MVP launched today, and iterate as you experiment with NFTs and the value it can bring your customers.
                 </p>
+                <p className="mx-auto mt-5 text-xl text-gray-500 max-w-prose">You can try out the demo <a className="text-indigo-600" href="https://demo.algomart.dev/" target="_blank" rel="noopener noreferrer">here</a></p>
               </div>
               <div className="mt-12">
                 <img
@@ -402,7 +403,19 @@ export default function HomePage() {
                 </p>
               </div>
 
-              <ul role="list" className="mt-12 mx-auto max-w-md px-4 grid gap-8 sm:max-w-lg sm:px-6 lg:px-8 lg:grid-cols-5 lg:max-w-7xl">
+              <ul role="list" className="mt-12 mx-auto max-w-md px-4 grid gap-8 sm:max-w-lg sm:px-6 lg:px-8 lg:3 lg:max-w-7xl">
+              <li className="relative">
+                  <a
+                    href="https://www.youtube.com/watch?v=qFibWdzgSAE"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="block w-full overflow-hidden bg-gray-100 rounded-lg group aspect-w-10 aspect-h-7 focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-offset-gray-100 focus-within:ring-indigo-500"
+                  >
+                    <img src="https://i.ytimg.com/vi_webp/qFibWdzgSAE/sddefault.webp" alt="" className="object-cover pointer-events-none group-hover:opacity-75" />
+                    <span className="sr-only">Developer Office Hours | AlgoMart</span>
+                  </a>
+                  <p className="block text-lg font-medium text-gray-900 pointer-events-none">Developer Office Hours | AlgoMart</p>
+                </li>
                 <li className="relative">
                   <a
                     href="https://www.youtube.com/watch?v=aETlcu7PTr4"


### PR DESCRIPTION
Added a link to the demo below the first paragraph
<img width="956" alt="Screen Shot 2022-04-19 at 3 18 55 PM" src="https://user-images.githubusercontent.com/1428054/164090266-812c2b0c-0de9-4950-b837-797d169a7900.png">

Added the Office Hours video to the list, and also changed it from 5 columns to 3, so that an odd number of videos wouldn't add big empty rows
<img width="1313" alt="Screen Shot 2022-04-19 at 3 19 19 PM" src="https://user-images.githubusercontent.com/1428054/164090433-0924244b-9d46-45fd-8e10-aea4f8ff2a89.png">

