### PR TITLE
Added missing title tag to page

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -12,6 +12,7 @@ import {
   XIcon,
 } from "@heroicons/react/outline"
 import { ChevronRightIcon, ExternalLinkIcon } from "@heroicons/react/solid"
+import Head from 'next/head';
 
 const navigation = [
   { name: "Overview", href: "#overview" },
@@ -123,6 +124,9 @@ function classNames(...classes) {
 export default function HomePage() {
   return (
     <div className="bg-white">
+      <Head>
+        <title>Algomart NFT Marketplace</title>
+      </Head>
       <Disclosure as="nav" className="bg-gray-900 sticky top-0 z-50">
         {({ isMobileMenuOpen }) => (
           <>


### PR DESCRIPTION
Fixes missing title for marketing page.

<img width="182" alt="Screenshot 2022-07-19 at 09 34 00" src="https://user-images.githubusercontent.com/4072018/179693245-8149795f-77f2-45e6-830f-f122d7f4dec5.png">

